### PR TITLE
Add DataFrame API notebook

### DIFF
--- a/notebooks/pyspark_dataframe_api_commands.ipynb
+++ b/notebooks/pyspark_dataframe_api_commands.ipynb
@@ -1,0 +1,123 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["# PySpark DataFrame API Commands for Interviews"]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["This notebook demonstrates basic and advanced examples of the PySpark DataFrame API."]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 1. Initialize Spark"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "from pyspark.sql import SparkSession\n\nspark = SparkSession.builder.appName('df-api-demo').getOrCreate()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 2. Create a DataFrame"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "data = [(1, 'Alice', 5), (2, 'Bob', 3), (3, 'Carol', 4)]\nschema = ['id', 'name', 'score']\ndf = spark.createDataFrame(data, schema)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 3. Select and Filter"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "df_filtered = df.select('id', 'name').filter(df.score > 3)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 4. Aggregation"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "agg_df = df.groupBy('name').agg({'score': 'avg'})"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 5. Join DataFrames"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "df2 = spark.createDataFrame([(1, 'NY'), (2, 'CA'), (3, 'TX')], ['id', 'state'])\njoined_df = df.join(df2, 'id', 'inner')"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 6. Window Functions"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "from pyspark.sql.window import Window\nfrom pyspark.sql.functions import row_number, desc\n\nwindow_spec = Window.orderBy(desc('score'))\nranked_df = df.withColumn('rank', row_number().over(window_spec))"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 7. Advanced Transformations"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "from pyspark.sql.functions import when\n\ndf_adv = df.withColumn('grade', when(df.score > 4, 'high').otherwise('low'))"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 8. Write Data as Delta"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "df.write.format('delta').mode('overwrite').save('/path/to/delta-table')"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary
- add new interview notebook with PySpark DataFrame API commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a244d4b48328821d5da82c947a1d