### PR TITLE
Adapt advanced PySpark features notebook for Colab

### DIFF
--- a/notebooks/pyspark_advanced_features.ipynb
+++ b/notebooks/pyspark_advanced_features.ipynb
@@ -1,0 +1,202 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Ejemplo avanzado de PySpark\n",
+    "Este notebook demuestra agregaciones, funciones de ventana, an\u00e1lisis, particiones y operaciones Delta Lake."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!pip install -q pyspark delta-spark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "from pyspark.sql import functions as F\n",
+    "from pyspark.sql.window import Window\n",
+    "spark = (SparkSession.builder.master('local[*]')\n",
+    "         .appName('PySparkAdvanced')\n",
+    "         .config('spark.sql.extensions', 'io.delta.sql.DeltaSparkSessionExtension')\n",
+    "         .config('spark.sql.catalog.spark_catalog', 'org.apache.spark.sql.delta.catalog.DeltaCatalog')\n",
+    "         .getOrCreate())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Preparar datos de ejemplo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "data = [\n",
+    "    (1, 'A', 10, '2024-01-01'),\n",
+    "    (2, 'A', 15, '2024-01-03'),\n",
+    "    (3, 'B', 20, '2024-01-07'),\n",
+    "    (4, 'B', 25, '2024-01-09'),\n",
+    "    (5, 'C', 30, '2024-01-10')\n",
+    "]\n",
+    "columns = ['id', 'categoria', 'valor', 'fecha']\n",
+    "df = spark.createDataFrame(data, columns)\n",
+    "df = df.withColumn('fecha', F.to_date('fecha'))\n",
+    "df.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Agregaci\u00f3n de datos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "agg_df = df.groupBy('categoria').agg(\n",
+    "    F.count('*').alias('conteo'),\n",
+    "    F.sum('valor').alias('suma_valor'),\n",
+    "    F.avg('valor').alias('promedio_valor')\n",
+    ")\n",
+    "agg_df.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Uso de funciones de ventana"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "window_spec = Window.partitionBy('categoria').orderBy('fecha')\n",
+    "df = df.withColumn('rn', F.row_number().over(window_spec))\n",
+    "df = df.withColumn('running_total', F.sum('valor').over(window_spec))\n",
+    "df.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. An\u00e1lisis de datos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "df.describe(['valor']).show()\n",
+    "top_valor = df.orderBy(F.desc('valor')).limit(1)\n",
+    "top_valor.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Particionamiento de datos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "path = '/content/delta_table'\n",
+    "df.write.format('delta').mode('overwrite').partitionBy('categoria').save(path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Partition pruning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "df_pruned = spark.read.format('delta').load(path).filter(F.col('categoria') == 'A')\n",
+    "df_pruned.explain(True)\n",
+    "df_pruned.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Delta merge"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from delta.tables import DeltaTable\n",
+    "new_data = [(2, 'A', 18, '2024-01-04'), (6, 'C', 40, '2024-01-11')]\n",
+    "updates = spark.createDataFrame(new_data, columns)\n",
+    "updates = updates.withColumn('fecha', F.to_date('fecha'))\n",
+    "delta_table = DeltaTable.forPath(spark, path)\n",
+    "delta_table.alias('t').merge(\n",
+    "    updates.alias('s'),\n",
+    "    't.id = s.id'\n",
+    ").whenMatchedUpdateAll().whenNotMatchedInsertAll().execute()\n",
+    "delta_table.toDF().show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "spark.stop()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a cell that installs pyspark and delta-spark
- configure a local Spark session with Delta extensions
- save Delta tables to `/content/delta_table`
- stop the Spark session at the end
